### PR TITLE
Update Makefile to stop relinking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dist-ssr
 *.sln
 *.sw?
 *.exe
+.installed-*

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,69 @@ PYINSTALLER = pyinstaller
 PIP = pip
 NPM = npm
 DIST_DIR = ..
+BACKEND_ENV = backend/Gomoku-env
+FRONTEND_DIST = render/dist
+BACKEND_DIST = backend/render_dist
+BACKEND_EXECUTABLE = Gomoku.exe
+BACKEND_REQUIREMENTS = backend/requirements.txt
+SERVER_SCRIPT = backend/server.py
 
-build: build-frontend build-backend
-	@echo Building frontend and backend complited
+ifeq ($(OS),Windows_NT)
+    ACTIVATE = backend\Gomoku-env\Scripts\activate
+	TOUCH = echo. >
+else
+    ACTIVATE = source $(BACKEND_ENV)/bin/activate
+	TOUCH = touch
+endif
 
-env:
+# Targets
+.PHONY: all build env install-backend build-backend install-frontend build-frontend install start clean fclean re
+
+all: build
+
+install: install-frontend install-backend
+
+build: install build-frontend build-backend
+	@echo Building frontend and backend completed
+
+start: build
+	./$(BACKEND_EXECUTABLE)
+
+#################### BACKEND ####################
+
+env: $(BACKEND_ENV)
+
+$(BACKEND_ENV):
 	@echo Creating virtual environment
 	cd backend && if not exist Gomoku-env ($(PYTHON) -m venv Gomoku-env)
-	backend\Gomoku-env\Scripts\activate && python.exe -m pip install --upgrade pip
+	$(ACTIVATE) && python.exe -m pip install --upgrade pip
 
-build-backend: env
+install-backend: $(BACKEND_INSTALLED_MARKER)
+
+$(BACKEND_INSTALLED_MARKER): $(BACKEND_ENV) $(BACKEND_REQUIREMENTS)
 	@echo Installing backend dependencies
-	backend\Gomoku-env\Scripts\activate && $(PIP) install -r backend/requirements.txt
-	cd backend && Gomoku-env\Scripts\activate && $(PYINSTALLER) --onefile --distpath $(DIST_DIR) --name Gomoku --add-data "render_dist:render_dist" --add-data "./server.py:." --add-data "api:api" --add-data "srcs:srcs" --hidden-import=numpy server.py
+	$(ACTIVATE) && $(PIP) install -r $(BACKEND_REQUIREMENTS)
+	$(TOUCH) $(BACKEND_INSTALLED_MARKER)
 
-build-frontend:
+build-backend: $(BACKEND_EXECUTABLE)
+
+$(BACKEND_EXECUTABLE): $(SERVER_SCRIPT) $(BACKEND_REQUIREMENTS)
+	@echo Building backend
+	$(ACTIVATE) && cd backend && $(PYINSTALLER) --onefile --distpath $(DIST_DIR) --name Gomoku --add-data "render_dist:render_dist" --add-data "./server.py:." --add-data "api:api" --add-data "srcs:srcs" --hidden-import=numpy server.py
+
+#################### FRONTEND ####################
+
+install-frontend: .installed-frontend
+
+.installed-frontend: render/package.json
 	@echo Installing frontend dependencies
 	cd render && $(NPM) install
-	cd render && $(NPM) run build
+	$(TOUCH) .installed-frontend
+
+
+build-frontend: $(BACKEND_DIST)
+
+$(BACKEND_DIST): $(FRONTEND_DIST)
 	@echo Copying dist folder to backend/render_dist
 ifeq ($(OS),Windows_NT)
 	xcopy /E /I /Y render\dist backend\render_dist
@@ -29,39 +74,43 @@ else
 	cp -rf render/dist backend/render_dist
 endif
 
-start: build
-	./Gomoku.exe
+$(FRONTEND_DIST): render/src/*
+	@echo Building frontend
+	cd render && $(NPM) run build
+
+#################### UTILS ####################
 
 clean:
 ifeq ($(OS),Windows_NT)
-	@echo removing Gomoku.exe
-	del /Q /F Gomoku.exe
-	@echo removing backend build
+	@echo Removing $(BACKEND_EXECUTABLE)
+	del /Q /F $(BACKEND_EXECUTABLE)
+	@echo Removing backend build
 	del /Q /F backend\Gomoku.spec
 	if exist backend\build rmdir /S /Q backend\build
-	if exist backend\render_dist rmdir /S /Q backend\render_dist
+	if exist $(BACKEND_DIST) rmdir /S /Q $(BACKEND_DIST)
 	for /d /r ./backend %%d in (__pycache__) do @if exist "%%d" rmdir /s /q "%%d"
-	@echo removing frontend build
-	if exist render\dist rmdir /S /Q render\dist
-
+	@echo Removing frontend build
+	if exist $(FRONTEND_DIST) rmdir /S /Q $(FRONTEND_DIST)
+	del /Q /F .installed-backend .installed-frontend
 else
-	@echo removing Gomoku.exe
-	rm -f Gomoku.exe
-	@echo removing backend build
+	@echo Removing $(BACKEND_EXECUTABLE)
+	rm -f $(BACKEND_EXECUTABLE)
+	@echo Removing backend build
 	rm -f backend/Gomoku.spec
 	rm -rf backend/build
-	rm -rf backend/render_dist
+	rm -rf $(BACKEND_DIST)
 	find backend -type d -name '__pycache__' -exec rm -r {} +
-	@echo removing frontend build
-	rm -rf render/dist
+	@echo Removing frontend build
+	rm -rf $(FRONTEND_DIST)
+	rm -f .installed-backend .installed-frontend
 endif
 
 fclean: clean
 ifeq ($(OS),Windows_NT)
-	rmdir /S /Q backend\Gomoku-env
+	rmdir /S /Q $(BACKEND_ENV)
 	rmdir /S /Q render\node_modules
 else
-	rm -rf backend/Gomoku-env
+	rm -rf $(BACKEND_ENV)
 	rm -rf render/node_modules
 endif
 


### PR DESCRIPTION
This pull request introduces several enhancements and improvements to the `Makefile` for better handling of the build process for both frontend and backend components. The changes include conditional logic for different operating systems, new targets for various build steps, and improved cleanup procedures.

Key changes include:

### Build Process Enhancements:
* Added new environment variables for backend and frontend paths, executable, and requirements (`BACKEND_ENV`, `FRONTEND_DIST`, `BACKEND_DIST`, `BACKEND_EXECUTABLE`, `BACKEND_REQUIREMENTS`, `SERVER_SCRIPT`).
* Introduced conditional logic to handle differences between Windows and Unix-like systems for activating virtual environments and file operations (`ACTIVATE`, `TOUCH`).

### New Targets:
* Added new targets for building, installing, and starting both frontend and backend (`all`, `install`, `build`, `start`).
* Created separate targets for backend and frontend installation and build steps (`install-backend`, `build-backend`, `install-frontend`, `build-frontend`).

### Cleanup Improvements:
* Enhanced the `clean` and `fclean` targets to remove additional files and directories, including backend and frontend build artifacts and installation markers.

Fixes #44 